### PR TITLE
infra: fix vscode build

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
     "version": "2.0.0",
     "configurations": [
         {
-            "name": "HelloWorld",
+            "name": "Bubble Dizzy Redux",
             "type": "cppdbg",
             "request": "launch",
             // Resolved by CMake Tools:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,7 @@
     "C_Cpp.clang_format_fallbackStyle": "Google",
     "C_Cpp.clang_format_sortIncludes": true,
     "C_Cpp.clang_format_style": "Google",
+    "C_Cpp.enhancedColorization": "enabled",
     "C_Cpp.formatting": "clangFormat",
     "editor.defaultFormatter": "ms-vscode.makefile-tools",
     "editor.defaultFoldingRangeProvider": "ms-vscode.makefile-tools",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ endif()
 # Enable C++20 Globally
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Enable C 17 Globally
 set(CMAKE_C_STANDARD 17)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -29,18 +29,32 @@
         {
             "name": "macos-ninja-release",
             "displayName": "macOS Ninja release",
-            "description": "MacOS Ninja",
+            "description": "Bubble Dizzy Redux MacOS Ninja",
             "inherits": "base-release"
         },
         {
             "name": "macos-xcode-release",
             "displayName": "macOS XCode release",
-            "description": "MacOS Xcode",
+            "description": "Bubble Dizzy Redux MacOS XCode",
             "inherits": "base-release",
             "generator": "Xcode"
+        },
+        {
+            "name": "macos-ninja-debug",
+            "displayName": "macOS Ninja debug",
+            "description": "Bubble Dizzy Redux MacOS Ninja (Debug)",
+            "inherits": "macos-ninja-release",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
         }
     ],
     "buildPresets": [
+        {
+            "name": "default-debug",
+            "hidden": true,
+            "configuration": "Debug"
+        },
         {
             "name": "default-release",
             "hidden": true,
@@ -55,6 +69,11 @@
             "name": "macos-xcode-release",
             "configurePreset": "macos-xcode-release",
             "inherits": "default-release"
+        },
+        {
+            "name": "macos-ninja-debug",
+            "configurePreset": "macos-ninja-debug",
+            "inherits": "default-debug"
         }
     ]
 }

--- a/src/engine/cmake/ConfigureCompiler.cmake
+++ b/src/engine/cmake/ConfigureCompiler.cmake
@@ -52,8 +52,30 @@ elseif(TARGET_PLATFORM STREQUAL "macOS Desktop")
 
   message(STATUS "Compiler: Xcode, version: " ${XCODE_VERSION})
 
-    set(CMAKE_C_FLAGS   "-Werror")
-    set(CMAKE_CXX_FLAGS "-Werror")
+  set(CMAKE_C_FLAGS   "-Werror -Weverything -pedantic-errors -Wno-missing-prototypes -Wno-c++98-compat -Wno-poison-system-directories -fshow-column -fshow-source-location -fcaret-diagnostics -fcolor-diagnostics -fdiagnostics-format=clang -fdiagnostics-show-option -fdiagnostics-show-category=id")
+  set(CMAKE_CXX_FLAGS "-Werror -Weverything -pedantic-errors -Wno-missing-prototypes -Wno-c++98-compat -Wno-poison-system-directories -fshow-column -fshow-source-location -fcaret-diagnostics -fcolor-diagnostics -fdiagnostics-format=clang -fdiagnostics-show-option -fdiagnostics-show-category=id")
+
+  set(CMAKE_C_FLAGS_DEBUG            "-g -D_DEBUG")
+  set(CMAKE_CXX_FLAGS_DEBUG          "-g -D_DEBUG")
+
+  set(CMAKE_C_FLAGS_RELWITHDEBINFO   "-O2 -g -D_DEBUG")
+  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -D_DEBUG")
+
+  set(CMAKE_C_FLAGS_RELEASE          "-O3 -DNDEBUG")
+  set(CMAKE_CXX_FLAGS_RELEASE        "-O3 -DNDEBUG")
+
+  set(CMAKE_STATIC_LINKER_FLAGS "")
+  set(CMAKE_EXE_LINKER_FLAGS    "")
+
+  set(CMAKE_STATIC_LINKER_FLAGS_DEBUG           "")
+  set(CMAKE_STATIC_LINKER_FLAGS_RELWITHDEBINFO  "")
+  set(CMAKE_STATIC_LINKER_FLAGS_RELEASE         "")
+
+  set(CMAKE_EXE_LINKER_FLAGS_DEBUG              "")
+  set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO     "")
+  set(CMAKE_EXE_LINKER_FLAGS_RELEASE            "")
+
+# stop on https://clang.llvm.org/docs/UsersManual.html#cmdoption-f-no-save-optimization-record
 
 endif()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated editor and build configuration descriptions for improved clarity.
  * Enabled enhanced colorization for C/C++ code in the editor.
  * Added new build presets for macOS Ninja Debug builds.
  * Improved compiler warning and diagnostic settings for macOS builds.
  * Enforced strict standard-compliant C++20 mode in the build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->